### PR TITLE
Sprite Scaling Error Fixes

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -828,7 +828,11 @@ class WME(tk.Tk):
             self.updateLevelScroll()
             return
         
-        offset = numpy.array(obj.offset)
+        try:
+            offset = numpy.array(obj.offset)
+        except Exception as e:
+            logging.warning(f'Failed to get offset for {obj.name}: {e}')
+            offset = numpy.array([0, 0])
         canvas_pos = numpy.array(obj.pos)
         canvas_pos = self.getObjectPosition(canvas_pos, offset)
         true_pos = self.getObjectPosition(obj.pos)
@@ -892,13 +896,17 @@ class WME(tk.Tk):
                 )
                 
             if len(obj._foreground) > 0:
-                self.level_canvas.create_image(
-                    canvas_pos[0],
-                    canvas_pos[1],
-                    anchor = 'c',
-                    image = obj.foreground_PhotoImage,
-                    tags = ('object', 'foreground', id)
-                )
+                try:
+                    self.level_canvas.create_image(
+                        canvas_pos[0],
+                        canvas_pos[1],
+                        anchor = 'c',
+                        image = obj.foreground_PhotoImage,
+                        tags = ('object', 'foreground', id)
+                    )
+                except Exception as e:
+                    logging.warning(f'Failed to create foreground image for {obj.name}: {e}')
+                    pass
             
             if len(obj._foreground) == 0 and len(obj._background) == 0:
                 self.level_canvas.create_image(


### PR DESCRIPTION
# Sprite Scaling Error Fixes
## Issues Fixed:
1. **PIL resize crash** - ValueError: height and width must be > 0 when sprites have invalid dimensions
2. **Level loading failures** - 16_p05_fill_it_up.xml (from `Where's my Xiyangyang?` game) crashing during object processing
3. **Multiple failure points** - Both offset calculation and foreground image rendering causing crashes

## Technical Details:
- **Root Cause**: Sprite scaling with zero/negative dimensions in wmwpy library
- **Error Chain**: obj.offset → sprite.image → PIL.resize() with invalid dimensions
- **Impact**: Complete level loading failure when any object has sprite issues

## Fixes Applied:
1. **Offset Access Protection** (Lines 831-835):
   ```python
   try:
       offset = numpy.array(obj.offset)
   except Exception as e:
       logging.warning(f'Failed to get offset for {obj.name}: {e}')
       offset = numpy.array([0, 0])
   ```

2. **Foreground Image Protection** (Lines 898-909):
   ```python
   if len(obj._foreground) > 0:
       try:
           self.level_canvas.create_image(
               canvas_pos[0], canvas_pos[1], anchor = 'c',
               image = obj.foreground_PhotoImage,
               tags = ('object', 'foreground', id)
           )
       except Exception as e:
           logging.warning(f'Failed to create foreground image for {obj.name}: {e}')
           pass
   ```

## Result:
- **Graceful error handling**: Objects with sprite issues are logged and skipped
- **Level loading completes**: 16_p05_fill_it_up.xml loads successfully
- **Robust processing**: Invalid sprites don't crash entire level load
- **Debug visibility**: Clear logging identifies problematic objects